### PR TITLE
Added --noreload option to server

### DIFF
--- a/scripts/tinkerserver
+++ b/scripts/tinkerserver
@@ -18,7 +18,7 @@ DAEMON="python $DIR/server.py"
 DAEMON_NAME=tinkerAccessServer
 
 # Add any command line options for your daemon here
-DAEMON_OPTS=""
+DAEMON_OPTS="--noreload"
 
 # This next line determines what user the script runs as.
 # Root generally not recommended but necessary if you are using the Raspberry Pi GPIO from Python.
@@ -40,6 +40,7 @@ do_start () {
 do_stop () {
     log_daemon_msg "Stopping system $DAEMON_NAME daemon"
     start-stop-daemon --stop --pidfile $PIDFILE --retry 10
+    rm -f $PIDFILE
     log_end_msg $?
 }
 

--- a/server.py
+++ b/server.py
@@ -311,4 +311,5 @@ def csvHTMLInterface():
 
 if __name__ == "__main__":
   #app.run(host='0.0.0.0')
-  app.run(host='0.0.0.0', debug=True)
+  use_reload = not (len(sys.argv) > 1 and sys.argv[1] == '--noreload')
+  app.run(host='0.0.0.0', debug=True, use_reloader=use_reload)


### PR DESCRIPTION
Prevents zombie server when run from /etc/init.d/tinkerserver. The Flask
server by default runs a child process, which is the actual webserver,
so that the parent can monitor the server files and restart the child
when they change. This, however, interferes with start-stop-daemon's
ability to stop the server. This change fixes that behavior.