### PR TITLE
WIP: image capture/posting

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -2,3 +2,10 @@
 password: hello
 db: /opt/tinkeraccess/db.db
 slackurl: https://hooks.slack.com/services/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
+webcam_username: <username>
+webcam_password: <password>
+imgur_client_id: <client_id>
+imgur_client_key: <client_key>
+
+[webcam_urls]
+ShopBot: http://10.2.0.14/ISAPI/Streaming/channels/1/picture


### PR DESCRIPTION
This adds the ability to configure the server to capture images of a tool from a webcam whenever someone logs in or out of that tool, and to attach those images to the Slack #machine_usage posts.

Because images cannot be directly attached to Slack webhook messages, I had to upload the image to Imgur. Alternatively, we could use a Slack bot (which can upload images). Using Imgur was easiest to get started, rather than bugging Ron to set up a Slack bot.