### PR TITLE
Run the server Slack webhook posts in a thread. This is done so that …

### DIFF
--- a/reinstall_server_only.sh
+++ b/reinstall_server_only.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+if [ "$(id -u)" != "0" ]; then
+   echo "This script must be run as root" 1>&2
+   exit 1
+fi
+
+dir="/opt/tinkeraccess"
+
+# if the directory doesn't exist create it
+if [ ! -d $dir ] ; then
+	echo "Target directory doesn't exist: $dir"
+	echo "	if this is a new installation, use install.sh"
+	exit
+fi
+
+# copy over the files we need
+cp server.py $dir
+chmod 755 $dir/server.py
+cp -r static $dir
+cp -r templates $dir
+cp devicemanager.py $dir
+
+# install the Server startup service
+service tinkerserver stop
+cp scripts/tinkerserver /etc/init.d
+chmod 755 /etc/init.d/tinkerserver
+update-rc.d tinkerserver defaults 91
+service tinkerserver start


### PR DESCRIPTION
Run the server Slack webhook posts in a thread. This is done so that the response
to the client is not held up by Slack being unreachable and the client timing out
waiting for a reply. The response to the client is done in parallel with posting
to Slack. This will fix the bug where TinkerAccess client fails to get
authentication when the Internet is down. This should also improve repsonse times
to the clients.